### PR TITLE
Initialize Flutter and Lambda starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# CRM
+# CRM ERP System
+
+This repository contains a simple starter project for a Customer Relationship Management (CRM) ERP system.
+The front-end is built with **Flutter**, while the backend uses **AWS Lambda** (Python) with **API Gateway** and **RDS** for data storage.
+
+## Project Structure
+
+```
+crm_app/                 Flutter application
+  lib/                   Dart source files
+  test/                  Widget tests
+backend/                 Sample Python Lambda function
+README.md                This documentation
+```
+
+## Getting Started
+
+### Flutter Frontend
+1. Install Flutter SDK (see [flutter.dev](https://docs.flutter.dev/get-started/install)).
+2. Navigate to `crm_app/` and run `flutter pub get` to fetch dependencies.
+3. Launch the app with `flutter run`.
+
+### AWS Backend
+1. Create an RDS instance (e.g., MySQL or PostgreSQL) and note the credentials.
+2. Deploy the Lambda function in `backend/lambda_function.py` using AWS Lambda (Python 3.9 runtime).
+   - Set environment variables `DB_HOST`, `DB_USER`, `DB_PASS`, and `DB_NAME` for database access.
+3. Configure an API Gateway endpoint that triggers the Lambda function.
+4. Update the Flutter app to call the API Gateway URL for data operations.
+
+This setup provides a starting point for developing a full ERP system. Expand each module (sales, inventory, accounting, etc.) inside the Flutter project and extend the Lambda functions to implement business logic.

--- a/backend/lambda_function.py
+++ b/backend/lambda_function.py
@@ -1,0 +1,30 @@
+import json
+import os
+import pymysql
+
+# Example credentials (load from environment variables or secrets manager)
+DB_HOST = os.environ.get('DB_HOST')
+DB_USER = os.environ.get('DB_USER')
+DB_PASS = os.environ.get('DB_PASS')
+DB_NAME = os.environ.get('DB_NAME')
+
+# Connection is created outside handler for re-use across invocations
+connection = None
+
+def get_connection():
+    global connection
+    if connection is None:
+        connection = pymysql.connect(host=DB_HOST, user=DB_USER, password=DB_PASS, database=DB_NAME)
+    return connection
+
+def lambda_handler(event, context):
+    conn = get_connection()
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT 'Hello from RDS' as message")
+        row = cursor.fetchone()
+
+    return {
+        'statusCode': 200,
+        'headers': {'Content-Type': 'application/json'},
+        'body': json.dumps({'message': row[0]})
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,1 @@
+pymysql

--- a/crm_app/lib/main.dart
+++ b/crm_app/lib/main.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'CRM ERP System',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const DashboardPage(),
+    );
+  }
+}
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: const Center(child: Text('Welcome to CRM ERP System')),
+    );
+  }
+}

--- a/crm_app/pubspec.yaml
+++ b/crm_app/pubspec.yaml
@@ -1,0 +1,17 @@
+name: crm_app
+description: A simple ERP system front-end in Flutter.
+version: 0.1.0
+
+environment:
+  sdk: '>=2.19.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/crm_app/test/widget_test.dart
+++ b/crm_app/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:crm_app/main.dart';
+
+void main() {
+  testWidgets('Dashboard shows welcome text', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    expect(find.text('Welcome to CRM ERP System'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add starter Flutter app skeleton under `crm_app`
- create backend Python Lambda function for RDS access
- document architecture and setup instructions in README
- include requirements for Lambda

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687de9221224832ea8330984b28c68ff