### PR TITLE
Add simple UI with dummy data

### DIFF
--- a/crm_app/lib/main.dart
+++ b/crm_app/lib/main.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'screens/dashboard.dart';
+import 'screens/customers.dart';
+import 'screens/sales.dart';
 
 void main() {
   runApp(const MyApp());
@@ -12,19 +15,55 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'CRM ERP System',
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: const DashboardPage(),
+      home: const HomePage(),
     );
   }
 }
 
-class DashboardPage extends StatelessWidget {
-  const DashboardPage({super.key});
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _selectedIndex = 0;
+
+  final List<Widget> _pages = const [
+    DashboardPage(),
+    CustomersPage(),
+    SalesPage(),
+  ];
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Dashboard')),
-      body: const Center(child: Text('Welcome to CRM ERP System')),
+      body: _pages[_selectedIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.dashboard),
+            label: 'Dashboard',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.people),
+            label: 'Customers',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.shopping_cart),
+            label: 'Sales',
+          ),
+        ],
+      ),
     );
   }
 }

--- a/crm_app/lib/screens/customers.dart
+++ b/crm_app/lib/screens/customers.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class CustomersPage extends StatelessWidget {
+  const CustomersPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final customers = [
+      'Acme Corp',
+      'Globex',
+      'Soylent Co',
+      'Initech',
+      'Umbrella Corp',
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Customers')),
+      body: ListView.builder(
+        itemCount: customers.length,
+        itemBuilder: (context, index) {
+          return ListTile(
+            leading: const Icon(Icons.person),
+            title: Text(customers[index]),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/crm_app/lib/screens/dashboard.dart
+++ b/crm_app/lib/screens/dashboard.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: const Center(
+        child: Text('Welcome to CRM ERP System'),
+      ),
+    );
+  }
+}

--- a/crm_app/lib/screens/sales.dart
+++ b/crm_app/lib/screens/sales.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class SalesPage extends StatelessWidget {
+  const SalesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final sales = [
+      {'item': 'Laptop', 'amount': 1200},
+      {'item': 'Printer', 'amount': 300},
+      {'item': 'Desk', 'amount': 150},
+      {'item': 'Monitor', 'amount': 200},
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sales')),
+      body: ListView.builder(
+        itemCount: sales.length,
+        itemBuilder: (context, index) {
+          final sale = sales[index];
+          return ListTile(
+            leading: const Icon(Icons.shopping_cart),
+            title: Text(sale['item'] as String),
+            trailing: Text('\$${sale['amount']}'),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add screens for Dashboard, Customers, and Sales
- implement bottom navigation in `main.dart`
- show dummy customers and sales data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc8b056e8832e83b73177c3867e1e